### PR TITLE
add pymprog to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pandas
 tensorflow
 networkx
 toposort
+pymprog
+


### PR DESCRIPTION
I needed to install pymprog as a dependency that wasn't in requirements.txt