### PR TITLE
Corrected typo in hsic.clust

### DIFF
--- a/cdt/causality/graph/PC.py
+++ b/cdt/causality/graph/PC.py
@@ -75,7 +75,7 @@ class PC(GraphModel):
         + dcc: "data=X, ic.method=\"dcc\""
         + hsic_gamma: "data=X, ic.method=\"hsic.gamma\""
         + hsic_perm: "data=X, ic.method=\"hsic.perm\""
-        + hsic_clus: "data=X, ic.method=\"hsic.clus\""
+        + hsic_clust: "data=X, ic.method=\"hsic.clust\""
         + corr: "C = cor(X), n = nrow(X)"
         + rcit: "data=X, ic.method=\"RCIT::RCIT\""
         + rcot: "data=X, ic.method=\"RCIT::RCoT\""
@@ -140,7 +140,7 @@ class PC(GraphModel):
         self.dir_method_indep = {'dcc': "data=X, ic.method=\"dcc\"",
                                  'hsic_gamma': "data=X, ic.method=\"hsic.gamma\"",
                                  'hsic_perm': "data=X, ic.method=\"hsic.perm\"",
-                                 'hsic_clus': "data=X, ic.method=\"hsic.clus\"",
+                                 'hsic_clust': "data=X, ic.method=\"hsic.clust\"",
                                  'corr': "C = cor(X), n = nrow(X)",
                                  'rcit': "data=X, ic.method=\"RCIT::RCIT\"",
                                  'rcot': "data=X, ic.method=\"RCIT::RCoT\""}


### PR DESCRIPTION
Hi @Diviyan-Kalainathan, thanks for making this awesome package available. 

I encountered a bug when using the PC class: the `hsic.clust` function is named 'hsic.clus' in the `dir_method_indep ` dictionnary, which causes the execution to fail. I corrected the typo in the following commit.

Cheers,
Alex