### PR TITLE
Added the metric SHD-CPDAG

### DIFF
--- a/cdt/metrics.py
+++ b/cdt/metrics.py
@@ -109,6 +109,79 @@ def precision_recall(target, prediction, low_confidence_undirected=False):
     return aupr, list(zip(precision, recall))
 
 
+def get_CPDAG(dag):
+    R"""Compute the completed partially directed acyclic graph (CPDAG) of
+    a given DAG
+
+    CPDAG is a Markov equivalence class of DAGs. Basically, it retain the
+    skeleton and the v-structures of the original DAG.
+
+    Args:
+        dag (numpy.ndarray or networkx.DiGraph): DAG, must be of
+            ones and zeros.
+
+    Returns:
+        numpy.ndarray: Adjacency matrix of the CPDAG.
+
+    """
+    if not RPackages.pcalg:
+        raise ImportError("pcalg R package is not available. Please check your installation.")
+
+    dag = retrieve_adjacency_matrix(dag)
+
+    os.makedirs('/tmp/cdt_CPDAG/')
+
+    def retrieve_result():
+        return np.loadtxt('/tmp/cdt_CPDAG/result.csv')
+
+    try:
+        np.savetxt('/tmp/cdt_CPDAG/dag.csv', dag, delimiter=',')
+        cpdag = launch_R_script("{}/utils/R_templates/cpdag.R".format(os.path.dirname(os.path.realpath(__file__))),
+                                    {"{dag}": '/tmp/cdt_CPDAG/dag.csv',
+                                     "{result}": '/tmp/cdt_CPDAG/result.csv'},
+                                    output_function=retrieve_result)
+    # Cleanup
+    except Exception as e:
+        rmtree('/tmp/cdt_CPDAG')
+        raise e
+    except KeyboardInterrupt:
+        rmtree('/tmp/cdt_CPDAG/')
+        raise KeyboardInterrupt
+
+    rmtree('/tmp/cdt_CPDAG')
+
+    return cpdag
+
+
+def SHD_CPDAG(target, pred):
+    r"""Compute the Structural Hamming Distance (SHD) between completed
+    partially directed acyclic graph (CPDAG).
+
+    The Structural Hamming Distance on CPDAG is simply the SHD
+    between two DAGs that are first mapped to their respective CPDAGs.
+    This distance can be particularly useful when an algorithm only
+    returns CPDAG.
+
+    Args:
+        target (numpy.ndarray or networkx.DiGraph): Target DAG, must be of
+            ones and zeros.
+        prediction (numpy.ndarray or networkx.DiGraph): DAG or CPDAG
+            predicted by the algorithm.
+
+    Returns:
+        int: Structural Hamming Distance on CPDAG (int).
+
+    """
+    true_labels = retrieve_adjacency_matrix(target)
+    predictions = retrieve_adjacency_matrix(pred, target.nodes()
+                                            if isinstance(target, nx.DiGraph) else None)
+
+    true_labels = get_CPDAG(true_labels)
+    predictions = get_CPDAG(predictions)
+
+    return SHD(true_labels, predictions, False)
+
+
 def SHD(target, pred, double_for_anticausal=True):
     r"""Compute the Structural Hamming Distance.
 

--- a/cdt/utils/R_templates/cpdag.R
+++ b/cdt/utils/R_templates/cpdag.R
@@ -1,0 +1,31 @@
+# MIT License
+#
+# Copyright (c) 2018 Diviyan Kalainathan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+library(pcalg)
+library(methods)
+
+dag <- read.csv(file="{dag}" , header=FALSE, sep=",")
+dag <- as(dag, "matrix")
+
+cpdag <- as(dag2cpdag(as(dag, "graphNEL")), "matrix")
+
+write.table(cpdag, file='{result}', row.names=FALSE, col.names=FALSE)


### PR DESCRIPTION
Some algorithms (e.g. GES and PC) returns CPDAG instead of DAG. To compare these methods with methods that return DAGs, SHD-CPDAG can be useful. Basically, it convert DAGs to their respective CPDAGs and then apply SHD.