### PR TITLE
Added SID for CPDAG

### DIFF
--- a/cdt/utils/R_templates/sid_cpdag.R
+++ b/cdt/utils/R_templates/sid_cpdag.R
@@ -1,0 +1,34 @@
+# MIT License
+#
+# Copyright (c) 2018 Diviyan Kalainathan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+library(SID)
+library(methods)
+
+target <- read.csv(file="{target}" , header=FALSE, sep=",")
+prediction <- read.csv(file="{prediction}" , header=FALSE, sep=",")
+
+result <- structIntervDist(target, prediction)
+SID_lower_bound <- result$sidLowerBound
+SID_upper_bound <- result$sidUpperBound
+
+write.table(SID_lower_bound, '{result_lower}', row.names=FALSE, col.names=FALSE)
+write.table(SID_upper_bound, '{result_upper}', row.names=FALSE, col.names=FALSE)


### PR DESCRIPTION
For some algorithms returning a CPDAG (like GES and PC), it can be useful to get a SID metric. A
 lower and an upper bound are returned which correspond to the best DAG and the worst DAG (respectively) of the Markov equivalence class.  For more information, the original article (https://arxiv.org/abs/1306.1043) that introduced SID has a dedicated section on this (see 2.4). 